### PR TITLE
Change to use prisma types generated instead of defining by self.

### DIFF
--- a/templates/front/next/pages/index.tsx
+++ b/templates/front/next/pages/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState, FormEvent, ChangeEvent } from 'react'
 import useAspidaSWR from '@aspida/swr'
 import styles from '~/styles/Home.module.css'
 import { apiClient } from '~/utils/apiClient'
-import { Task } from '$/types'
+import { Task } from '<%= orm === "prisma" ? "$prisma/client" : "$/types" %>'
 import UserBanner from '~/components/UserBanner'
 
 const Home = () => {

--- a/templates/front/next/tsconfig.json
+++ b/templates/front/next/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],
-      "$/*": ["./server/*"]
+      "$/*": ["./server/*"]<% if (orm === 'prisma') { %>,
+      "$prisma/*": ["./server/node_modules/.prisma/*"]<% } %>
     },
     "allowJs": true,
     "skipLibCheck": true,

--- a/templates/front/nuxt/pages/index.vue
+++ b/templates/front/nuxt/pages/index.vue
@@ -34,7 +34,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { Task } from '$/types'
+import { Task } from '<%= orm === "prisma" ? "$prisma/client" : "$/types" %>'
 
 export default Vue.extend({
   async fetch() {

--- a/templates/front/nuxt/tsconfig.json
+++ b/templates/front/nuxt/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "~/*": ["./*"],
       "@/*": ["./*"],
-      "$/*": ["./server/*"]
+      "$/*": ["./server/*"]<% if (orm === 'prisma') { %>,
+      "$prisma/*": ["./server/node_modules/.prisma/*"]<% } %>
     },<% var axiosType = aspida === 'axios' ? ', "@nuxtjs/axios"' : '' %>
     "types": ["@types/node", "@nuxt/types"<%- axiosType %>]
   },

--- a/templates/orm/prisma/server/service/tasks.ts
+++ b/templates/orm/prisma/server/service/tasks.ts
@@ -1,6 +1,5 @@
-import { PrismaClient } from '@prisma/client'<% if (testing !== 'none') { %>
+import { PrismaClient, Task, TaskUpdateInput } from '$prisma/client'<% if (testing !== 'none') { %>
 import { depend } from 'velona'<% } %>
-import { Task } from '$/types'
 
 const prisma = new PrismaClient()
 
@@ -15,7 +14,7 @@ export const createTask = (label: Task['label']) =>
 
 export const updateTask = (
   id: Task['id'],
-  partialTask: Partial<Pick<Task, 'label' | 'done'>>
+  partialTask: TaskUpdateInput
 ) => prisma.task.update({ where: { id }, data: partialTask })
 
 export const deleteTask = (id: Task['id']) =>

--- a/templates/orm/prisma/server/types/index.ts
+++ b/templates/orm/prisma/server/types/index.ts
@@ -1,0 +1,5 @@
+export type UserInfo = {
+  id: string
+  name: string
+  icon: string
+}

--- a/templates/server/api/tasks/_taskId@number/index.ts
+++ b/templates/server/api/tasks/_taskId@number/index.ts
@@ -1,4 +1,4 @@
-import { Task } from '$/types'
+import { Task } from '<%= orm === "prisma" ? "$prisma/client" : "$/types" %>'
 
 export type Methods = {
   patch: {

--- a/templates/server/api/tasks/index.ts
+++ b/templates/server/api/tasks/index.ts
@@ -1,4 +1,4 @@
-import { Task } from '$/types'
+import { Task } from '<%= orm === "prisma" ? "$prisma/client" : "$/types" %>'
 
 export type Methods = {
   get: {

--- a/templates/server/service/tasks.ts
+++ b/templates/server/service/tasks.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'<% if (testing !== 'none') { %>
 import { depend } from 'velona'<% } %>
-import { Task } from '$/types'
+import { Task } from '<%= orm === "prisma" ? "$prisma/client" : "$/types" %>'
 
 type DB = {
   nextId: number

--- a/templates/server/tsconfig.json
+++ b/templates/server/tsconfig.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-      "$/*": ["./*"]
+      "$/*": ["./*"]<% if (orm === 'prisma') { %>,
+      "$prisma/*": ["./node_modules/.prisma/*"]<% } %>
     },
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [ ] Feature
- [x] Code style update
- [ ] Refactoring
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->

I tested `create-frourio-app` with `prisma`, then I felt it's nice except redefining types we already written in schema!
I'm very new comer for prisma, so I don't have confidence if I can use this way with more huge scheme or not.

`$prisma/*` definition is needed for frontend. I think not the only way for achieving it...

I tested with `node ./lib/cli.js foo && cd foo && yarn build` using `Fastify + Next.js + prsima + sqlite` and `Express + Nuxt.js + prsima + sqlite`, and `node ./lib/cli.js foo && cd foo && yarn typecheck` using `Fastify + Next.js + typeorm + mysql`.

( By the way, `yarn typecheck` was failed in other points in server... )

( And more, https://github.com/LumaKernel/create-frourio-app/blob/prisma-types/lib/cli.js#L40-L40 this link is dead. )

Thanks in advance.