### PR TITLE
fix: use `waitFor` because `waitForDomChange` is already deprecated.

### DIFF
--- a/server/templates/@testing=jest/@client=next/test/pages/index.test.tsx
+++ b/server/templates/@testing=jest/@client=next/test/pages/index.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'<% if (reactHooks === 'swr') { %>
 import { cache } from 'swr'<% } else if (reactHooks === 'none') { %>
-import { render, fireEvent, waitFor } from '@testing-library/react'<% } %>
+import { render, fireEvent, waitFor, act } from '@testing-library/react'<% } %>
 import dotenv from 'dotenv'
 import Fastify, { FastifyInstance } from 'fastify'
 import cors from 'fastify-cors'
 import aspida from '@aspida/<%= aspida === 'axios' ? 'axios' : 'node-fetch' %>'
 import api from '~/server/api/$api'
 import Home from '~/pages/index'<% if (reactHooks !== 'none') { %>
-import { render, fireEvent, waitFor } from '../testUtils'<% } %>
+import { render, fireEvent, waitFor, act } from '../testUtils'<% } %>
 
 dotenv.config({ path: 'server/.env' })
 
@@ -42,7 +42,8 @@ describe('Home page', () => {
   it('matches snapshot', async () => {
     const { asFragment } = render(<Home />, {})
 
-    await waitFor(() => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
       expect(asFragment()).toMatchSnapshot()
     })
   })

--- a/server/templates/@testing=jest/@client=next/test/pages/index.test.tsx
+++ b/server/templates/@testing=jest/@client=next/test/pages/index.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'<% if (reactHooks === 'swr') { %>
 import { cache } from 'swr'<% } else if (reactHooks === 'none') { %>
-import { render, fireEvent, waitForDomChange } from '@testing-library/react'<% } %>
+import { render, fireEvent, waitFor } from '@testing-library/react'<% } %>
 import dotenv from 'dotenv'
 import Fastify, { FastifyInstance } from 'fastify'
 import cors from 'fastify-cors'
 import aspida from '@aspida/<%= aspida === 'axios' ? 'axios' : 'node-fetch' %>'
 import api from '~/server/api/$api'
 import Home from '~/pages/index'<% if (reactHooks !== 'none') { %>
-import { render, fireEvent, waitForDomChange } from '../testUtils'<% } %>
+import { render, fireEvent, waitFor } from '../testUtils'<% } %>
 
 dotenv.config({ path: 'server/.env' })
 
@@ -40,25 +40,25 @@ afterAll(() => fastify.close())
 
 describe('Home page', () => {
   it('matches snapshot', async () => {
-    const { container, asFragment } = render(<Home />, {})
+    const { asFragment } = render(<Home />, {})
 
-    await waitForDomChange({ container: container as HTMLElement })
-
-    expect(asFragment()).toMatchSnapshot()
+    await waitFor(() => {
+      expect(asFragment()).toMatchSnapshot()
+    })
   })
 
   it('clicking button triggers prompt', async () => {
-    const { container, getByText } = render(<Home />, {})
-
-    await waitForDomChange({ container: container as HTMLElement })
+    const { getByText } = render(<Home />, {})
 
     window.prompt = jest.fn()
     window.alert = jest.fn()
-    fireEvent.click(getByText('LOGIN') as any)
 
-    expect(window.prompt).toHaveBeenCalledWith(
-      'Enter the user id (See server/.env)'
-    )
-    expect(window.alert).toHaveBeenCalledWith('Login failed')
+    await waitFor(() => {
+      fireEvent.click(getByText('LOGIN'))
+      expect(window.prompt).toHaveBeenCalledWith(
+        'Enter the user id (See server/.env)'
+      )
+      expect(window.alert).toHaveBeenCalledWith('Login failed')
+    })
   })
 })


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

In an environment where `Next.js` and `Jest` is introduced with `npx create-frourio-app`, warnings are printed as follows when running `npm run test` in a project root:

```
 PASS  test/pages/index.test.tsx
  ● Console

    console.warn
      `waitForDomChange` has been deprecated. Use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.

      at waitForDomChange (node_modules/@testing-library/dom/dist/wait-for-dom-change.js:28:13)
      at node_modules/@testing-library/dom/dist/wait-for-dom-change.js:61:54
      at node_modules/@testing-library/react/dist/pure.js:57:22
      at node_modules/@testing-library/react/dist/act-compat.js:61:24
      at batchedUpdates$1 (node_modules/react-dom/cjs/react-dom.development.js:22380:12)
      at act (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1042:14)
      at node_modules/@testing-library/react/dist/act-compat.js:60:20
```

Issue Number: N/A

`waitForDomChange` is already deprecated, therefore, I used `waitFor` instead.
https://testing-library.com/docs/dom-testing-library/api-async/#waitfordomchange
