### PR TITLE
feat(templates): add fields to ormconfig

### DIFF
--- a/server/templates/server/@orm=typeorm/ormconfig.ts
+++ b/server/templates/server/@orm=typeorm/ormconfig.ts
@@ -23,7 +23,9 @@ const options: ConnectionOptions = {
   entities: ['entity/**/*.ts'],
   migrations: ['migration/**/*.ts'],
   cli: {
-    migrationsDir: 'migration'
+    migrationsDir: 'migration',
+    subscribersDir: 'subscriber',
+    entitiesDir: 'entity'
   }
 }
 


### PR DESCRIPTION
It's useful when using typeorm cli.

typeorm 設定で使ってて、あると便利だと思った設定です。 `yarn typeorm entity:create` とかできれいに動いてくれます。