### PR TITLE
fix: test is run under root repository, but node_modules/ on root will be used accidentally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# test
-/.tmp/
-
 # local env files
 /.env
 /.env.local

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,8 +7,8 @@ const config: Config.InitialOptions = {
   testEnvironment: 'node',
   setupFiles: ['dotenv/config'],
   setupFilesAfterEnv: ['jest-expect-message'],
-  testPathIgnorePatterns: ['/templates/', '/.tmp/'],
-  modulePathIgnorePatterns: ['/templates/', '/.tmp/'],
+  testPathIgnorePatterns: ['/templates/'],
+  modulePathIgnorePatterns: ['/templates/'],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/'
   })

--- a/server/templates/@testing=jest/@client=next/@dev-dep
+++ b/server/templates/@testing=jest/@client=next/@dev-dep
@@ -1,2 +1,4 @@
 @testing-library/react
 identity-obj-proxy
+fastify
+fastify-cors

--- a/server/tests/generate.spec.ts
+++ b/server/tests/generate.spec.ts
@@ -46,7 +46,7 @@ const tempSandbox = async (
   answers: Answers,
   main: (dir: string) => Promise<void>
 ) => {
-  const tmpDir = process.env.TEST_CFA_TMP_DIR || './.tmp'
+  const tmpDir = process.env.TEST_CFA_TMP_DIR || '/tmp/cfa-test'
   try {
     await fs.promises.mkdir(tmpDir, { recursive: true })
   } catch (e: unknown) {

--- a/server/utils/database/jest-context.ts
+++ b/server/utils/database/jest-context.ts
@@ -7,7 +7,7 @@ import {
 import path from 'path'
 
 export const createJestDbContext = (): AllDbContext => {
-  const tmpDir = process.env.TEST_CFA_TMP_DIR || './.tmp'
+  const tmpDir = process.env.TEST_CFA_TMP_DIR || '/tmp/cfa-test'
   const sqliteTmpDir = path.resolve(tmpDir, 'sqlite')
 
   const ctx: AllDbContext = {


### PR DESCRIPTION
`./.tmp` にテストで作成して、みたいな仕組みにしましたが、親の node_modules/ を見に行く都合で必要な依存がちゃんと入っているかテストしきれていないようなので、もとの `/tmp/` 配下のディレクトリをデフォルトにしました。

next + jest で抜けてるものがあって気づきました、そこの修正もこれから含めます。。

## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->
