### PR TITLE
fix: pin react types versions

### DIFF
--- a/server/pretense/package.json
+++ b/server/pretense/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^17.0.15",
     "@types/node-fetch": "^2.5.10",
     "@types/react": "^17.0.39",
+    "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
     "@vendia/serverless-express": "^4.5.3",

--- a/server/templates/@client=next/@dev-dep
+++ b/server/templates/@client=next/@dev-dep
@@ -1,5 +1,6 @@
 @types/node
 @types/react
+@types/react-dom
 @typescript-eslint/eslint-plugin
 @typescript-eslint/parser
 cross-env

--- a/server/templates/@client=next/package.json
+++ b/server/templates/@client=next/package.json
@@ -32,5 +32,9 @@
     "test": "jest<% } %>",
     "pretypecheck": "npm run generate",
     "typecheck": "tsc --noEmit && tsc --noEmit -p server"
-  }
+  }<% if (pm === 'yarn') { %>,
+  "resolutions": {
+    "@types/react": "^17",
+    "@types/react-dom": "^17"
+  }<% } %>
 }


### PR DESCRIPTION
`@testing-library/react` depends on `@types/react-dom@*` and yarn
installs v18. It is not time to switch to v18. Then pin the versions of
them.

related: https://github.com/vercel/next.js/issues/36019

<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

- ...


## Additional context


## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
